### PR TITLE
Fix inconsistent hash in SplObjectStorage

### DIFF
--- a/php_weak_functions.c
+++ b/php_weak_functions.c
@@ -131,32 +131,6 @@ PHP_FUNCTION(object_handle) /* {{{ */
     RETURN_LONG((uint32_t)Z_OBJ_HANDLE_P(zv));
 }  /* }}} */
 
-#ifdef PHP_WEAK_PATCH_SPL_OBJECT_HASH
-PHP_FUNCTION(spl_object_hash_patched)
-{
-    zval *obj;
-    zend_string *hash = NULL;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "o", &obj) == FAILURE) {
-        return;
-    }
-
-    php_weak_referent_t *referent = php_weak_referent_find_ptr((zend_ulong)Z_OBJ_HANDLE_P(obj));
-
-    if (NULL != referent) {
-        Z_OBJ_P(obj)->handlers = referent->original_handlers;
-        hash = php_spl_object_hash(obj);
-        Z_OBJ_P(obj)->handlers = &referent->custom_handlers;
-    }
-
-    if (NULL == hash) {
-        hash = php_spl_object_hash(obj);
-    }
-
-    RETURN_NEW_STR(hash);
-} /* }}} */
-#endif
-
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(refcounted_arg, 0, 1, _IS_BOOL, NULL, 0)
                 ZEND_ARG_INFO(0, value)
@@ -182,12 +156,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(object_handle_arg, 0, 1, IS_LONG, NULL, 
                 ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
-#ifdef PHP_WEAK_PATCH_SPL_OBJECT_HASH
-ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_object_hash, 0, 0, 1)
-    ZEND_ARG_INFO(0, obj)
-ZEND_END_ARG_INFO()
-#endif
-
 
 const zend_function_entry php_weak_functions[] = { /* {{{ */
     PHP_NAMED_FE(Weak\\refcounted, PHP_FN(refcounted), refcounted_arg)
@@ -198,10 +166,6 @@ const zend_function_entry php_weak_functions[] = { /* {{{ */
     PHP_NAMED_FE(Weak\\weakrefs, PHP_FN(weakrefs), weakrefs_arg)
 
     PHP_NAMED_FE(Weak\\object_handle, PHP_FN(object_handle), object_handle_arg)
-
-#ifdef PHP_WEAK_PATCH_SPL_OBJECT_HASH
-    PHP_NAMED_FE(Weak\\spl_object_hash, PHP_FN(spl_object_hash_patched), arginfo_spl_object_hash)
-#endif
 
     PHP_FE_END
 }; /* }}} */

--- a/tests/002-reference-spl_object_storage_debug_hash_consistent.phpt
+++ b/tests/002-reference-spl_object_storage_debug_hash_consistent.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Weak\Reference - SplObjectStorage hashes in debug output still consistent before and after wrapping
+--SKIPIF--
+<?php if (!extension_loaded("weak")) print "skip";  ?>
+--FILE--
+<?php
+
+/** @var \Testsuite $helper */
+$helper = require '.testsuite.php';
+
+$s = new SplObjectStorage();
+$obj = new stdClass();
+$original_hash = spl_object_hash($obj);
+$s->attach($obj);
+$wr = new Weak\Reference($obj);
+$current_hash = spl_object_hash($obj);
+$helper->assert('Stored in SplObjectStorage weak-referenced object hash matches origin one', $original_hash == $current_hash);
+
+ob_start();
+debug_zval_dump($s);
+$res = ob_get_contents();
+ob_end_clean();
+
+$helper->assert('Object hash in SplObjectStorage debug output not changed', false !== strpos($res, $original_hash));
+$helper->line();
+
+debug_zval_dump($original_hash);
+debug_zval_dump($current_hash);
+echo $res;
+
+$helper->line();
+
+?>
+EOF
+--EXPECTF--
+Stored in SplObjectStorage weak-referenced object hash matches origin one: ok
+Object hash in SplObjectStorage debug output not changed: ok
+
+string(32) "%s" refcount(2)
+string(32) "%s" refcount(2)
+object(SplObjectStorage)#2 (1) refcount(2){
+  ["storage":"SplObjectStorage":private]=>
+  array(1) refcount(1){
+    ["%s"]=>
+    array(2) refcount(1){
+      ["obj"]=>
+      object(stdClass)#3 (0) refcount(2){
+      }
+      ["inf"]=>
+      NULL
+    }
+  }
+}
+
+EOF

--- a/tests/002-reference-spl_object_storage_hash_consistent.phpt
+++ b/tests/002-reference-spl_object_storage_hash_consistent.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Weak\Reference - spl_object_hash still consistent before and after wrapping
+Weak\Reference - SplObjectStorage::getHash() still consistent before and after wrapping
 --SKIPIF--
 <?php if (!extension_loaded("weak")) print "skip";  ?>
 --FILE--
@@ -10,33 +10,52 @@ $helper = require '.testsuite.php';
 
 $obj = new stdClass();
 
+$s = new SplObjectStorage();
 
-$original_hash = spl_object_hash($obj);
+$original_hash = $s->getHash($obj);
 
 $wr = new Weak\Reference($obj);
 
-$current_hash = spl_object_hash($obj);
+$current_hash = $s->getHash($obj);
 
 $helper->assert('Wrapped object hash matches origin one', $original_hash == $current_hash);
 
 
 $wr2 = new Weak\Reference($obj);
 
-$double_hash = spl_object_hash($obj);
+$double_hash = $s->getHash($obj);
 $helper->assert('Repeatedly wrapped object hash does not changes', $current_hash == $double_hash);
 
 $wr = null;
 
-$again_hash = spl_object_hash($obj);
+$again_hash = $s->getHash($obj);
 $helper->assert('Repeatedly wrapped object hash does not changes after some reference death', $current_hash == $again_hash);
 
 $wr2 = null;
 
-$nullified_hash = spl_object_hash($obj);
+$nullified_hash = $s->getHash($obj);
 $helper->assert('Wrapped object hash still not changed even after all references died', $current_hash == $original_hash);
 $helper->assert('Wrapped object hash still the same even after all references died', $current_hash == $nullified_hash);
 
 $helper->line();
+
+$s = new SplObjectStorage();
+$obj = new stdClass();
+$original_hash = spl_object_hash($obj);
+$s->attach($obj);
+$current_hash = spl_object_hash($obj);
+$helper->assert('Stored in SplObjectStorage object hash matches origin one', $original_hash == $current_hash);
+
+$s = new SplObjectStorage();
+$obj = new stdClass();
+$original_hash = spl_object_hash($obj);
+$wr = new Weak\Reference($obj);
+$s->attach($wr);
+$current_hash = spl_object_hash($obj);
+$helper->assert('Stored in SplObjectStorage weak-referenced object hash matches origin one', $original_hash == $current_hash);
+
+$helper->line();
+
 ?>
 EOF
 --EXPECT--
@@ -45,5 +64,8 @@ Repeatedly wrapped object hash does not changes: ok
 Repeatedly wrapped object hash does not changes after some reference death: ok
 Wrapped object hash still not changed even after all references died: ok
 Wrapped object hash still the same even after all references died: ok
+
+Stored in SplObjectStorage object hash matches origin one: ok
+Stored in SplObjectStorage weak-referenced object hash matches origin one: ok
 
 EOF


### PR DESCRIPTION
This PR:
- fix inconsistent hash returned by `SplObjectStorage::getHash()` (PHP <= 7.0.2 affected) ;
- fix inconsistent hash shown in `SplObjectStorage` debug output  (PHP <= 7.0.2 affected);
- patches `spl_object_hash()` zend_function on low-level instead of replacing it `EG(function_table)`  (PHP <= 7.0.2 affected).
