### PR TITLE
[WIP] Make Weak\Reference callable and return referent object on invoke

### DIFF
--- a/php_weak_reference.c
+++ b/php_weak_reference.c
@@ -609,6 +609,8 @@ static const zend_function_entry php_weak_reference_methods[] = { /* {{{ */
         PHP_ME(WeakReference, valid, arginfo_weak_reference_valid, ZEND_ACC_PUBLIC)
         PHP_ME(WeakReference, notifier, arginfo_weak_reference_notifier, ZEND_ACC_PUBLIC)
 
+        PHP_MALIAS(WeakReference, __invoke, get, arginfo_weak_reference_get, ZEND_ACC_PUBLIC)
+        
         PHP_FE_END
 }; /* }}} */
 

--- a/stubs/weak/Reference.php
+++ b/stubs/weak/Reference.php
@@ -60,4 +60,13 @@ class Reference
     public function notifier($notify = null)
     {
     }
+
+    /**
+     * Get referent object. This method is alias of Reference::get().
+     *
+     * @return object | null
+     */
+    public function __invoke()
+    {
+    }
 }

--- a/tests/002-reference-callable.phpt
+++ b/tests/002-reference-callable.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Weak\Reference - weakref object is callable and return referent object
+--SKIPIF--
+<?php if (!extension_loaded("weak")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Testsuite $helper */
+$helper = require '.testsuite.php';
+
+$obj = new stdClass();
+
+$wr = new Weak\Reference($obj);
+
+$helper->header('When referent object alive');
+$helper->assert('Referent object alive', $wr() === $obj);
+$helper->assert('Referent object valid', $wr->valid());
+$helper->dump($wr);
+$helper->space();
+
+$obj = null;
+
+
+$helper->header('When referent object dead');
+$helper->assert('Referent object dead', $wr() === null);
+$helper->assert('Referent object invalid', $wr->valid(), false);
+$helper->dump($wr);
+$helper->line();
+?>
+EOF
+--EXPECT--
+When referent object alive:
+---------------------------
+Referent object alive: ok
+Referent object valid: ok
+object(Weak\Reference)#3 (2) refcount(3){
+  ["referent":"Weak\Reference":private]=>
+  object(stdClass)#2 (0) refcount(2){
+  }
+  ["notifier":"Weak\Reference":private]=>
+  NULL
+}
+
+
+When referent object dead:
+--------------------------
+Referent object dead: ok
+Referent object invalid: ok
+object(Weak\Reference)#3 (2) refcount(3){
+  ["referent":"Weak\Reference":private]=>
+  NULL
+  ["notifier":"Weak\Reference":private]=>
+  NULL
+}
+
+EOF


### PR DESCRIPTION
While this is brings `Weak\Reference` close to how python's [`weakref.ref`](https://docs.python.org/3.5/library/weakref.html#weakref.ref) works, I'm still not sure whether this should be added.
