### PR TITLE
Fix invalid behavior when setting invalid or callable array notifier

### DIFF
--- a/php_weak_reference.h
+++ b/php_weak_reference.h
@@ -32,6 +32,10 @@ extern void php_weak_globals_referents_ht_dtor(zval *zv);
 #define PHP_WEAK_REFERENCE_FETCH(zv) php_weak_reference_fetch_object(Z_OBJ_P(zv))
 #define PHP_WEAK_REFERENCE_FETCH_INTO(pzval, into) php_weak_reference_t *(into) = PHP_WEAK_REFERENCE_FETCH((pzval));
 
+#define PHP_WEAK_NOTIFIER_INVALID    0
+#define PHP_WEAK_NOTIFIER_NULL       1
+#define PHP_WEAK_NOTIFIER_ARRAY      2
+#define PHP_WEAK_NOTIFIER_CALLBACK   3
 
 struct _php_weak_referent_t {
     zval this_ptr;
@@ -47,6 +51,7 @@ struct _php_weak_reference_t {
     php_weak_referent_t *referent;
 
     zval notifier;
+    int notifier_type;
 
     zval this_ptr;
     zend_object std;

--- a/tests/002-reference-notifier_callable_array.phpt
+++ b/tests/002-reference-notifier_callable_array.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Weak\Reference - callable notifier passed as array
+--SKIPIF--
+<?php if (!extension_loaded("weak")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Testsuite $helper */
+$helper = require '.testsuite.php';
+
+
+class Test
+{
+    public $wr;
+
+    public function __construct($obj)
+    {
+        $this->wr = new Weak\Reference($obj, [$this, 'notifier']);
+    }
+
+    public function notifier()
+    {
+        echo 'Notified', PHP_EOL;
+    }
+}
+
+$obj = new stdClass();
+$t = new Test($obj);
+$obj = null;
+
+$helper->line();
+?>
+EOF
+--EXPECT--
+Notified
+
+EOF

--- a/tests/002-reference-notifier_callable_string.phpt
+++ b/tests/002-reference-notifier_callable_string.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Weak\Reference - callable notifier passed as string
+--SKIPIF--
+<?php if (!extension_loaded("weak")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Testsuite $helper */
+$helper = require '.testsuite.php';
+
+
+function notifier()
+{
+    echo 'Notified', PHP_EOL;
+}
+
+$obj = new stdClass();
+$wr = new Weak\Reference($obj, 'notifier');
+$obj = null;
+
+$helper->line();
+?>
+EOF
+--EXPECT--
+Notified
+
+EOF

--- a/tests/002-reference-notifier_change.phpt
+++ b/tests/002-reference-notifier_change.phpt
@@ -46,6 +46,18 @@ $helper->assert('Notifier is null', $wr->notifier(), null);
 $obj = null;
 $helper->line();
 
+$notifier = 'var_dump';
+$wr->notifier($notifier);
+
+try {
+    $wr->notifier('nonexistent');
+} catch (Error $e) {
+    $helper->exception_export($e);
+}
+
+$helper->assert('Notifier stays the same', $wr->notifier(), $notifier);
+$helper->line();
+
 ?>
 EOF
 --EXPECT--
@@ -62,5 +74,8 @@ Callback notified
 Notifier is callback by default: ok
 Notifier was callback: ok
 Notifier is null: ok
+
+TypeError: Argument 2 passed to Weak\Reference::notifier() must be callable, array or null, string given
+Notifier stays the same: ok
 
 EOF


### PR DESCRIPTION
This PR:
- fixes callable passed as array, e.g. `[$this, 'someMethod']` interpreted as array notifier rather then callable;
- fixes invalid notifier set, even when throwing exception.
