### PR TITLE
Fix false exception

### DIFF
--- a/tests/.testsuite.php
+++ b/tests/.testsuite.php
@@ -41,9 +41,15 @@ class Testsuite
             $this->exception_export($e->getPrevious());
         }
 
-        foreach ($e->getExceptions() as $thrown) {
-            echo '    ';
-            $this->exception_export($thrown);
+        if (!empty($e->getExceptions())) {
+            echo 'thrown:', PHP_EOL;
+            foreach ($e->getExceptions() as $id => $thrown) {
+                echo '    #' . $id . ': ';
+                $this->exception_export($thrown);
+                if ($thrown->getPrevious()) {
+                    echo '        previous: ', $this->exception_export($thrown->getPrevious());
+                }
+            }
         }
     }
 

--- a/tests/002-WeakReference-exception-before-and-from-notifier.phpt
+++ b/tests/002-WeakReference-exception-before-and-from-notifier.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Ref\WeakReference - exception thrown outside notifier before destructing and in notifier
+--SKIPIF--
+<?php if (!extension_loaded("ref")) print "skip"; ?>
+--FILE--
+<?php
+
+use Ref\NotifierException;
+use Ref\WeakReference;
+
+/** @var \Testsuite $helper */
+$helper = require '.testsuite.php';
+
+function test()
+{
+    $obj = new stdClass();
+
+    $wr = new WeakReference($obj, function () {
+        throw new RuntimeException('From weak notifier');
+    });
+
+    throw new RuntimeException('Test exception');
+}
+
+try {
+    test();
+} catch (NotifierException $e) {
+    $helper->ref_exception_export($e);
+}
+
+?>
+EOF
+--EXPECT--
+Ref\NotifierException: One or more exceptions thrown during notifiers calling
+previous: RuntimeException: Test exception
+thrown:
+    #0: RuntimeException: From weak notifier
+EOF

--- a/tests/002-WeakReference-exception-before-notifier.phpt
+++ b/tests/002-WeakReference-exception-before-notifier.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Ref\WeakReference - exception thrown outside notifier before destructing
+--SKIPIF--
+<?php if (!extension_loaded("ref")) print "skip"; ?>
+--FILE--
+<?php
+
+use Ref\WeakReference;
+
+/** @var \Testsuite $helper */
+$helper = require '.testsuite.php';
+
+function test()
+{
+    $obj = new stdClass();
+
+    $wr = new WeakReference($obj, function () {
+        echo 'Weak notifier called', PHP_EOL;
+    });
+
+    throw new RuntimeException('Test exception');
+}
+
+try {
+    test();
+} catch (Throwable $e) {
+    $helper->exception_export($e);
+}
+
+?>
+EOF
+--EXPECT--
+Weak notifier called
+RuntimeException: Test exception
+EOF

--- a/tests/002-WeakReference-exception_in_callback.phpt
+++ b/tests/002-WeakReference-exception_in_callback.phpt
@@ -30,5 +30,6 @@ EOF
 --EXPECT--
 WeakTests\TrackingDtor's destructor called
 Ref\NotifierException: One or more exceptions thrown during notifiers calling
-    Exception: Test exception from callback
+thrown:
+    #0: Exception: Test exception from callback
 EOF

--- a/tests/002-WeakReference-exception_in_multiple_callbacks.phpt
+++ b/tests/002-WeakReference-exception_in_multiple_callbacks.phpt
@@ -54,7 +54,8 @@ Callback #3 called
 Callback #4 called
 Callback #5 called
 Ref\NotifierException: One or more exceptions thrown during notifiers calling
-    Exception: Test exception from callback #1
-    Exception: Test exception from callback #3
+thrown:
+    #0: Exception: Test exception from callback #1
+    #1: Exception: Test exception from callback #3
 
 EOF

--- a/tests/002-WeakReference-exception_in_orig_dtor.phpt
+++ b/tests/002-WeakReference-exception_in_orig_dtor.phpt
@@ -38,5 +38,6 @@ EOF
 Dtor called
 Weak callback called
 Ref\NotifierException: One or more exceptions thrown during notifiers calling
-    Exception: Test exception from dtor
+thrown:
+    #0: Exception: Test exception from dtor
 EOF

--- a/tests/002-WeakReference-exception_in_orig_dtor_and_callback.phpt
+++ b/tests/002-WeakReference-exception_in_orig_dtor_and_callback.phpt
@@ -41,6 +41,7 @@ EOF
 Dtor called
 Callback called
 Ref\NotifierException: One or more exceptions thrown during notifiers calling
-    Exception: Test exception from dtor
-    Exception: Test exception from callback
+thrown:
+    #0: Exception: Test exception from dtor
+    #1: Exception: Test exception from callback
 EOF

--- a/tests/002-WeakReference-notifier_not_called_after_wr_dies_first.phpt
+++ b/tests/002-WeakReference-notifier_not_called_after_wr_dies_first.phpt
@@ -39,7 +39,8 @@ EOF
 --EXPECT--
 Weak notifier called
 Ref\NotifierException: One or more exceptions thrown during notifiers calling
-    Exception: Destructor throws exception
+thrown:
+    #0: Exception: Destructor throws exception
 
 Referent object dead: ok
 Referent object invalid: ok

--- a/tests/004-SoftReference-exception-before-and-from-notifier.phpt
+++ b/tests/004-SoftReference-exception-before-and-from-notifier.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Ref\SoftReference - exception thrown outside notifier before destructing and in notifier
+--SKIPIF--
+<?php if (!extension_loaded("ref")) print "skip"; ?>
+--FILE--
+<?php
+
+use Ref\NotifierException;
+use Ref\SoftReference;
+
+/** @var \Testsuite $helper */
+$helper = require '.testsuite.php';
+
+function test()
+{
+    $obj = new stdClass();
+
+    $sr = new SoftReference($obj, function () {
+        throw new RuntimeException('From soft notifier');
+    });
+
+    throw new RuntimeException('Test exception');
+}
+
+try {
+    test();
+} catch (NotifierException $e) {
+    $helper->ref_exception_export($e);
+}
+
+?>
+EOF
+--EXPECT--
+Ref\NotifierException: One or more exceptions thrown during notifiers calling
+previous: RuntimeException: Test exception
+thrown:
+    #0: RuntimeException: From soft notifier
+EOF

--- a/tests/004-SoftReference-exception-before-notifier.phpt
+++ b/tests/004-SoftReference-exception-before-notifier.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Ref\SoftReference - exception thrown outside notifier before destructing
+--SKIPIF--
+<?php if (!extension_loaded("ref")) print "skip"; ?>
+--FILE--
+<?php
+
+use Ref\SoftReference;
+
+/** @var \Testsuite $helper */
+$helper = require '.testsuite.php';
+
+function test()
+{
+    $obj = new stdClass();
+
+    $sr = new SoftReference($obj, function () {
+        echo 'Soft notifier called', PHP_EOL;
+    });
+
+    throw new RuntimeException('Test exception');
+}
+
+try {
+    test();
+} catch (Throwable $e) {
+    $helper->exception_export($e);
+}
+
+?>
+EOF
+--EXPECT--
+Soft notifier called
+RuntimeException: Test exception
+EOF

--- a/tests/004-SoftReference-exception_in_callback.phpt
+++ b/tests/004-SoftReference-exception_in_callback.phpt
@@ -30,5 +30,6 @@ EOF
 --EXPECT--
 WeakTests\TrackingDtor's destructor called
 Ref\NotifierException: One or more exceptions thrown during notifiers calling
-    Exception: Test exception from callback
+thrown:
+    #0: Exception: Test exception from callback
 EOF

--- a/tests/004-SoftReference-exception_in_multiple_callbacks.phpt
+++ b/tests/004-SoftReference-exception_in_multiple_callbacks.phpt
@@ -54,7 +54,8 @@ Callback #4 called
 Callback #5 called
 WeakTests\TrackingDtor's destructor called
 Ref\NotifierException: One or more exceptions thrown during notifiers calling
-    Exception: Test exception from callback #1
-    Exception: Test exception from callback #3
+thrown:
+    #0: Exception: Test exception from callback #1
+    #1: Exception: Test exception from callback #3
 
 EOF

--- a/tests/004-SoftReference-exception_in_orig_dtor.phpt
+++ b/tests/004-SoftReference-exception_in_orig_dtor.phpt
@@ -38,5 +38,6 @@ EOF
 Weak callback called
 Dtor called
 Ref\NotifierException: One or more exceptions thrown during notifiers calling
-    Exception: Test exception from dtor
+thrown:
+    #0: Exception: Test exception from dtor
 EOF

--- a/tests/004-SoftReference-exception_in_orig_dtor_and_callback.phpt
+++ b/tests/004-SoftReference-exception_in_orig_dtor_and_callback.phpt
@@ -41,6 +41,7 @@ EOF
 Callback called
 Dtor called
 Ref\NotifierException: One or more exceptions thrown during notifiers calling
-    Exception: Test exception from callback
-    Exception: Test exception from dtor
+thrown:
+    #0: Exception: Test exception from callback
+    #1: Exception: Test exception from dtor
 EOF

--- a/tests/004-SoftReference-notifier_not_called_after_wr_dies_first.phpt
+++ b/tests/004-SoftReference-notifier_not_called_after_wr_dies_first.phpt
@@ -39,7 +39,8 @@ EOF
 --EXPECT--
 Weak notifier called
 Ref\NotifierException: One or more exceptions thrown during notifiers calling
-    Exception: Destructor throws exception
+thrown:
+    #0: Exception: Destructor throws exception
 
 Referent object dead: ok
 Referent object invalid: ok

--- a/tests/005-Soft-and-Weak-Reference-exception-before-and-from-notifier.phpt
+++ b/tests/005-Soft-and-Weak-Reference-exception-before-and-from-notifier.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Ref\SoftReference + Ref\WeakReference - exception thrown outside notifier before destructing and in notifier
+--SKIPIF--
+<?php if (!extension_loaded("ref")) print "skip"; ?>
+--FILE--
+<?php
+
+use Ref\NotifierException;
+use Ref\SoftReference;
+use Ref\WeakReference;
+
+/** @var \Testsuite $helper */
+$helper = require '.testsuite.php';
+
+function test()
+{
+    $obj = new stdClass();
+
+    $sr = new SoftReference($obj, function () {
+        throw new RuntimeException('From soft notifier');
+    });
+
+    $wr = new WeakReference($obj, function () {
+        throw new RuntimeException('From weak notifier');
+    });
+
+    throw new RuntimeException('Test exception');
+}
+
+try {
+    test();
+} catch (NotifierException $e) {
+    $helper->ref_exception_export($e);
+}
+
+?>
+EOF
+--EXPECT--
+Ref\NotifierException: One or more exceptions thrown during notifiers calling
+previous: RuntimeException: Test exception
+thrown:
+    #0: RuntimeException: From soft notifier
+    #1: RuntimeException: From weak notifier
+EOF

--- a/tests/005-Soft-and-Weak-Reference-exception-before-notifier.phpt
+++ b/tests/005-Soft-and-Weak-Reference-exception-before-notifier.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Ref\SoftReference + Ref\WeakReference - exception thrown outside notifier before destructing
+--SKIPIF--
+<?php if (!extension_loaded("ref")) print "skip"; ?>
+--FILE--
+<?php
+
+use Ref\SoftReference;
+use Ref\WeakReference;
+
+/** @var \Testsuite $helper */
+$helper = require '.testsuite.php';
+
+function test()
+{
+    $obj = new stdClass();
+
+    $sr = new SoftReference($obj, function () {
+        echo 'Soft notifier called', PHP_EOL;
+    });
+
+    $wr = new WeakReference($obj, function () {
+        echo 'Weak notifier called', PHP_EOL;
+    });
+
+    throw new RuntimeException('Test exception');
+}
+
+try {
+    test();
+} catch (Throwable $e) {
+    $helper->exception_export($e);
+}
+
+?>
+EOF
+--EXPECT--
+Soft notifier called
+Weak notifier called
+RuntimeException: Test exception
+EOF


### PR DESCRIPTION
This PR fixes problem when false `Ref\NotifierException` thrown during object destruction if non-caught exception was thrown before such destruction (outside notifiers and referent object destructor).
